### PR TITLE
CHANGE: Deploy now allows for as many subnets and instances as region…

### DIFF
--- a/vault-core-instances.json
+++ b/vault-core-instances.json
@@ -1,10 +1,6 @@
 {
 "AWSTemplateFormatVersion" : "2010-09-09",
-"Description" : "Hashicorp Vault Reference: Core EC2 Instances: This template creates the EC2 instances used to run Hashicorp Vault.",
-
-	"Metadata" :
-	{
-	},
+"Description" : "HASHICORP VAULT REFERENCE (Core Instances Infrastructure) - Creates a Bastion server in one of the Public subnets and an Vault EC2 instance in each of the Private subnets.",
 
 	"Parameters" :
 	{
@@ -13,17 +9,61 @@
       {
         "Description": "Name of the stack containing the vault security",
         "Type": "String"
+      },
+      
+      "NumberOfSubnetNodes" :
+      {
+        "Description" : "Vault Core Infrastructure - Default, Min and Max Values for Number of Subnets (and therefore Instances) created to serve the Vault Core Software",
+        "Type" : "Number",
+        "Default" : 2,
+        "MinValue" : 2,
+        "MaxValue" : 5
       }
   
   },
 
 	"Mappings" :
 	{
+	  
+	    "RegionAZMap" :
+      {
+          "us-east-1" : { "1" : "us-east-1a", "2" : "us-east-1b", "3" : "us-east-1c", "4" : "us-east-1d", "5" : "us-east-1e" },
+          "us-east-2" : { "1" : "us-east-2a", "2" : "us-east-2b", "3" : "us-east-2c" },
+          "us-west-1" : { "1" : "us-west-1b", "2" : "us-west-1c" },
+          "us-west-2" : { "1" : "us-west-2a", "2" : "us-west-2b", "3" : "us-west-2c" },
+          "ca-central-1" : { "1" : "ca-central-1a", "2" : "ca-central-1b" },
+          "eu-west-1" : { "1" : "eu-west-1a", "2" : "eu-west-1b", "3" : "eu-west-1c"  },
+          "eu-central-1" : { "1" : "eu-central-1a", "2" : "eu-central-1b" },
+          "eu-west-2" : { "1" : "eu-west-2a", "2" : "eu-west-2b" },
+          "ap-southeast-1" : { "1" : "ap-southeast-1a", "2" : "ap-southeast-1b"  },
+          "ap-southeast-2" : { "1" : "ap-southeast-2a", "2" : "ap-southeast-2b", "3" : "ap-southeast-2c" },
+          "ap-northeast-2" : { "1" : "ap-northeast-2a", "2" : "ap-northeast-2c" },
+          "ap-northeast-1" : { "1" : "ap-northeast-1a", "2" : "ap-northeast-1c" },
+          "ap-south-1" : { "1" : "ap-south-1a", "2" : "ap-south-1b" },
+          "sa-east-1" : { "1" : "sa-east-1a", "2" : "sa-east-1b", "3" : "sa-east-1c" }
+      }
+
   },
 
-	"Conditions" :
+  "Conditions" :
 	{
-  },
+	      "CreateNode5" :
+	      { "Fn::Equals" :
+            [ { "Ref" : "NumberOfSubnetNodes" }, 5 ]
+	      },
+        "CreateNode4" :
+        { "Fn::Or" :
+            [ { "Fn::Equals" : [ { "Ref" : "NumberOfSubnetNodes" }, 4 ] }, { "Condition" : "CreateNode5" }]
+        },
+        "CreateNode3" :
+        { "Fn::Or" :
+            [ { "Fn::Equals" : [ { "Ref" : "NumberOfSubnetNodes" }, 3 ] }, { "Condition" : "CreateNode4" }]
+        },
+        "CreateNode2" :
+        { "Fn::Or" :
+            [ { "Fn::Equals" : [ { "Ref" : "NumberOfSubnetNodes" }, 2 ] }, { "Condition" : "CreateNode3" }]
+        }
+	},
 
 	"Resources" :
   {
@@ -164,8 +204,8 @@
         }
       }
     },
-
-    "VaultEC2InstanceProfile" :
+    
+   "VaultEC2InstanceProfile" :
     {
       "Type" : "AWS::IAM::InstanceProfile",
       "Properties" :
@@ -174,7 +214,7 @@
         "Roles" : [{ "Ref" : "VaultEC2InstanceRole" }]
       }
     },
-
+    
     "VaultEC2InstancePolicy" :
     {
       "Type" : "AWS::IAM::Policy",
@@ -207,9 +247,9 @@
         "Properties" :
         {
           "EbsOptimized" : "false",
-          "ImageId" : "ami-70edb016",
-          "InstanceType" : "t2.micro",
-          "KeyName" : "palindrome_2017",
+          "ImageId" : { "Fn::GetAtt" : ["NetworkInfo","VaultImageID"] },
+          "InstanceType" : { "Fn::GetAtt" : ["NetworkInfo","VaultInstanceType"] },
+          "KeyName" : { "Fn::GetAtt" : ["NetworkInfo","VaultEC2KeyPair"] },
           "NetworkInterfaces": [
           {
                 "AssociatePublicIpAddress": true,
@@ -223,16 +263,16 @@
           "Tags" : [ { "Key" : "Name", "Value" : "vault_public_access_instance" } ]
         }
     },
-    
+
     "VaultEC2Instance1" :
     {
         "Type" : "AWS::EC2::Instance",
         "Properties" :
         {
           "EbsOptimized" : "false",
-          "ImageId" : "ami-70edb016",
-          "InstanceType" : "t2.micro",
-          "KeyName" : "palindrome_2017",
+          "ImageId" : { "Fn::GetAtt" : ["NetworkInfo","VaultImageID"] },
+          "InstanceType" : { "Fn::GetAtt" : ["NetworkInfo","VaultInstanceType"] },
+          "KeyName" : { "Fn::GetAtt" : ["NetworkInfo","VaultEC2KeyPair"] },
           "SecurityGroupIds" : [{ "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSG"] }],
           "SubnetId" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet1"] },
           "IamInstanceProfile" : { "Ref" : "VaultEC2InstanceProfile"},
@@ -264,13 +304,376 @@
             }
          }
 	 
+    },
+ 
+    "VaultEC2Instance2" :
+    {
+        "Type" : "AWS::EC2::Instance",
+        "Properties" :
+        {
+          "EbsOptimized" : "false",
+          "ImageId" : { "Fn::GetAtt" : ["NetworkInfo","VaultImageID"] },
+          "InstanceType" : { "Fn::GetAtt" : ["NetworkInfo","VaultInstanceType"] },
+          "KeyName" : { "Fn::GetAtt" : ["NetworkInfo","VaultEC2KeyPair"] },
+          "SecurityGroupIds" : [{ "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSG"] }],
+          "SubnetId" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet2"] },
+          "IamInstanceProfile" : { "Ref" : "VaultEC2InstanceProfile"},
+          "Tags" : [ { "Key" : "Name", "Value" : "vault_private_instance" } ],
+          "UserData" :
+             {
+               "Fn::Base64" : { "Fn::Join" : [ "",
+                ["#!/bin/bash -v\n",
+                "sudo yum -y update\n",
+                "builtin cd /usr/local/bin/\n",
+                "wget https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_linux_amd64.zip\n",
+                "wget https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_SHA256SUMS\n",
+                "sha256sum -c vault_0.7.0_SHA256SUMS 2>&1 | grep OK\n",
+                "unzip vault_0.7.0_linux_amd64.zip\n",
+                "sudo rm vault_0.7.0_linux_amd64.zip\n",
+                "builtin cd /usr/local/etc/\n",
+                "wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/config.hcl\n",
+                "sudo easy_install supervisor\n",
+                "builtin cd /usr/local/etc/\n",
+                "wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/supervisord.conf\n",
+                "builtin cd /etc/init.d/\n",
+                "sudo wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/supervisord\n",
+                "sudo chmod +x /etc/init.d/supervisord\n",
+                "sudo chkconfig --add supervisord\n",
+                "sudo service supervisord start\n"
+                
+              ]
+              ] }
+            }
+         }
+    },
+    
+    "VaultEC2Instance3" :
+    {
+        "Type" : "AWS::EC2::Instance",
+        "Condition" : "CreateNode3",
+        "Properties" :
+        {
+          "EbsOptimized" : "false",
+          "ImageId" : { "Fn::GetAtt" : ["NetworkInfo","VaultImageID"] },
+          "InstanceType" : { "Fn::GetAtt" : ["NetworkInfo","VaultInstanceType"] },
+          "KeyName" : { "Fn::GetAtt" : ["NetworkInfo","VaultEC2KeyPair"] },
+          "SecurityGroupIds" : [{ "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSG"] }],
+          "SubnetId" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet3"] },
+          "IamInstanceProfile" : { "Ref" : "VaultEC2InstanceProfile"},
+          "Tags" : [ { "Key" : "Name", "Value" : "vault_private_instance" } ],
+          "UserData" :
+             {
+               "Fn::Base64" : { "Fn::Join" : [ "",
+                ["#!/bin/bash -v\n",
+                "sudo yum -y update\n",
+                "builtin cd /usr/local/bin/\n",
+                "wget https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_linux_amd64.zip\n",
+                "wget https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_SHA256SUMS\n",
+                "sha256sum -c vault_0.7.0_SHA256SUMS 2>&1 | grep OK\n",
+                "unzip vault_0.7.0_linux_amd64.zip\n",
+                "sudo rm vault_0.7.0_linux_amd64.zip\n",
+                "builtin cd /usr/local/etc/\n",
+                "wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/config.hcl\n",
+                "sudo easy_install supervisor\n",
+                "builtin cd /usr/local/etc/\n",
+                "wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/supervisord.conf\n",
+                "builtin cd /etc/init.d/\n",
+                "sudo wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/supervisord\n",
+                "sudo chmod +x /etc/init.d/supervisord\n",
+                "sudo chkconfig --add supervisord\n",
+                "sudo service supervisord start\n"
+                
+              ]
+              ] }
+            }
+         }
+    },
+    
+    "VaultEC2Instance4" :
+    {
+        "Type" : "AWS::EC2::Instance",
+        "Condition" : "CreateNode4",
+        "Properties" :
+        {
+          "EbsOptimized" : "false",
+          "ImageId" : { "Fn::GetAtt" : ["NetworkInfo","VaultImageID"] },
+          "InstanceType" : { "Fn::GetAtt" : ["NetworkInfo","VaultInstanceType"] },
+          "KeyName" : { "Fn::GetAtt" : ["NetworkInfo","VaultEC2KeyPair"] },
+          "SecurityGroupIds" : [{ "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSG"] }],
+          "SubnetId" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet4"] },
+          "IamInstanceProfile" : { "Ref" : "VaultEC2InstanceProfile"},
+          "Tags" : [ { "Key" : "Name", "Value" : "vault_private_instance" } ],
+          "UserData" :
+             {
+               "Fn::Base64" : { "Fn::Join" : [ "",
+                ["#!/bin/bash -v\n",
+                "sudo yum -y update\n",
+                "builtin cd /usr/local/bin/\n",
+                "wget https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_linux_amd64.zip\n",
+                "wget https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_SHA256SUMS\n",
+                "sha256sum -c vault_0.7.0_SHA256SUMS 2>&1 | grep OK\n",
+                "unzip vault_0.7.0_linux_amd64.zip\n",
+                "sudo rm vault_0.7.0_linux_amd64.zip\n",
+                "builtin cd /usr/local/etc/\n",
+                "wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/config.hcl\n",
+                "sudo easy_install supervisor\n",
+                "builtin cd /usr/local/etc/\n",
+                "wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/supervisord.conf\n",
+                "builtin cd /etc/init.d/\n",
+                "sudo wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/supervisord\n",
+                "sudo chmod +x /etc/init.d/supervisord\n",
+                "sudo chkconfig --add supervisord\n",
+                "sudo service supervisord start\n"
+                
+              ]
+              ] }
+            }
+         }
+    },
+    
+    "VaultEC2Instance5" :
+    {
+        "Type" : "AWS::EC2::Instance",
+        "Condition" : "CreateNode5",
+        "Properties" :
+        {
+          "EbsOptimized" : "false",
+          "ImageId" : { "Fn::GetAtt" : ["NetworkInfo","VaultImageID"] },
+          "InstanceType" : { "Fn::GetAtt" : ["NetworkInfo","VaultInstanceType"] },
+          "KeyName" : { "Fn::GetAtt" : ["NetworkInfo","VaultEC2KeyPair"] },
+          "SecurityGroupIds" : [{ "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSG"] }],
+          "SubnetId" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet5"] },
+          "IamInstanceProfile" : { "Ref" : "VaultEC2InstanceProfile"},
+          "Tags" : [ { "Key" : "Name", "Value" : "vault_private_instance" } ],
+          "UserData" :
+             {
+               "Fn::Base64" : { "Fn::Join" : [ "",
+                ["#!/bin/bash -v\n",
+                "sudo yum -y update\n",
+                "builtin cd /usr/local/bin/\n",
+                "wget https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_linux_amd64.zip\n",
+                "wget https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_SHA256SUMS\n",
+                "sha256sum -c vault_0.7.0_SHA256SUMS 2>&1 | grep OK\n",
+                "unzip vault_0.7.0_linux_amd64.zip\n",
+                "sudo rm vault_0.7.0_linux_amd64.zip\n",
+                "builtin cd /usr/local/etc/\n",
+                "wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/config.hcl\n",
+                "sudo easy_install supervisor\n",
+                "builtin cd /usr/local/etc/\n",
+                "wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/supervisord.conf\n",
+                "builtin cd /etc/init.d/\n",
+                "sudo wget https://raw.githubusercontent.com/mike-goodwin/aws-vault-reference-infrastructure/master/supervisord\n",
+                "sudo chmod +x /etc/init.d/supervisord\n",
+                "sudo chkconfig --add supervisord\n",
+                "sudo service supervisord start\n"
+                
+              ]
+              ] }
+            }
+         }
+    },
+    
+    "VaultInternalELB2Nodes" :
+    {
+        "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+        "Condition" : "CreateNode2",
+        "Properties" :
+        {
+  
+          "CrossZone" : "true",
+          "Instances" : [ { "Ref" : "VaultEC2Instance1" },{ "Ref" : "VaultEC2Instance2" } ],
+          "Listeners" : [ { "LoadBalancerPort" : "8200", "InstancePort" : "8200" ,"Protocol" : "TCP"} ],
+          "Subnets" : [
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet1"] },
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet2"] }
+                      ]
+        }
+      
+    },
+    
+    "VaultInternalELB3Nodes" :
+    {
+        "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+        "Condition" : "CreateNode3",
+        "Properties" :
+        {
+  
+          "CrossZone" : "true",
+          "Instances" : [ { "Ref" : "VaultEC2Instance1" },{ "Ref" : "VaultEC2Instance2" },{ "Ref" : "VaultEC2Instance3" } ],
+          "Listeners" : [ { "LoadBalancerPort" : "8200", "InstancePort" : "8200" ,"Protocol" : "TCP"} ],
+          "Subnets" : [
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet1"] },
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet2"] },
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet3"] }
+                      ]
+        }
+      
+    },
+    
+    "VaultInternalELB4Nodes" :
+    {
+        "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+        "Condition" : "CreateNode4",
+        "Properties" :
+        {
+  
+          "CrossZone" : "true",
+          "Instances" : [ { "Ref" : "VaultEC2Instance1" },{ "Ref" : "VaultEC2Instance2" },{ "Ref" : "VaultEC2Instance3" },{ "Ref" : "VaultEC2Instance4" } ],
+          "Listeners" : [ { "LoadBalancerPort" : "8200", "InstancePort" : "8200" ,"Protocol" : "TCP"} ],
+          "Subnets" : [
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet1"] },
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet2"] },
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet3"] },
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet4"] }
+                      ]
+        }
+      
+    },
+    
+    "VaultInternalELB5Nodes" :
+    {
+        "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+        "Condition" : "CreateNode5",
+        "Properties" :
+        {
+  
+          "CrossZone" : "true",
+          "Instances" : [ { "Ref" : "VaultEC2Instance1" },{ "Ref" : "VaultEC2Instance2" },{ "Ref" : "VaultEC2Instance3" },{ "Ref" : "VaultEC2Instance4" },{ "Ref" : "VaultEC2Instance5" } ],
+          "Listeners" : [ { "LoadBalancerPort" : "8200", "InstancePort" : "8200" ,"Protocol" : "TCP"} ],
+          "Subnets" : [
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet1"] },
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet2"] },
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet3"] },
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet4"] },
+                        { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet5"] }
+                      ]
+        }
+      
     }
-      
-      
       
   },
 
 	"Outputs" :
 	{
+
+	  "VaultRefVPC":
+		{
+		  "Description": "VAULT CORE REFERENCE: VPC ID",
+	   "Value": { "Fn::GetAtt" : ["NetworkInfo","VaultRefVPC"] }
+	  },
+	  "VaultPublicSubnet1" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 1",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSubnet1"] }
+    },
+	  
+		"VaultPublicSubnet2" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 2",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSubnet2"] }
+    },
+    
+		"VaultPublicSubnet3" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 3",
+      "Condition" : "CreateNode3",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSubnet3"] }
+    },
+    
+		"VaultPublicSubnet4" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 4",
+      "Condition" : "CreateNode4",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSubnet4"] }
+    },
+    
+		"VaultPublicSubnet5" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 5",
+      "Condition" : "CreateNode5",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSubnet5"] }
+    },
+    
+	  "VaultPrivateSubnet1" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 1",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet1"] }
+    },
+    
+    "VaultPrivateSubnet2" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 2",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet2"] }
+    },
+    
+    "VaultPrivateSubnet3" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 3",
+      "Condition" : "CreateNode3",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet3"] }
+    },
+    
+    "VaultPrivateSubnet4" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 4",
+      "Condition" : "CreateNode4",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet4"] }
+    },
+    
+    "VaultPrivateSubnet5" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 5",
+      "Condition" : "CreateNode5",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet5"] }
+    },
+    
+    "VaultCIDRBastionAccess" :
+	  {
+      "Description": "VAULT CORE REFERENCE: CIDR of IP used for access to Bastion host",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultCIDRBastionAccess"] }
+    },
+    
+    "VaultImageID" :
+    {
+      "Description": "VAULT CORE REFERENCE: Image ID of AMI used for Vault Core Infrastructure",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultImageID"] }
+    },
+    
+    "VaultInstanceType" :
+    {
+      "Description": "VAULT CORE REFERENCE: Instance Type used for Vault Core Infrastructure",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultInstanceType"] }
+    },
+    
+    "VaultEC2KeyPair" :
+    {
+      "Description": "VAULT CORE REFERENCE: Key Pair used for Vault EC2 Instances",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultEC2KeyPair"] }
+    },
+    
+    "VaultPublicSG" :
+	  {
+      "Description": "VAULT CORE REFERENCE: Public Instance Security Group",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSG"] }
+    },
+    
+    "VaultPrivateSG" :
+	  {
+      "Description": "VAULT CORE REFERENCE: Private Instance Security Group",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSG"] }
+    },
+    
+    "RoleName" :
+    {
+      "Description": "VAULT CORE REFERENCE - (VPC Peering): Cross Account Role Name",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","RoleName"] }
+    },
+    
+    "VaultAppAWSAccount" :
+    {
+      "Description": "VAULT CORE REFERENCE - (VPC Peering): AWS Account Number in which the App VPC is created",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultAppAWSAccount"] }
+    }
+
   }
 }

--- a/vault-core-networking-parameters.json
+++ b/vault-core-networking-parameters.json
@@ -4,43 +4,67 @@
 		  "ParameterValue": "10.0.0.0/16"
 	  },
   	{
-    	"ParameterKey": "AvailabilityZones",
-		  "ParameterValue": "eu-west-1a,eu-west-1b,eu-west-1c"
+    	"ParameterKey": "CIDRForPublicSubnet1",
+		  "ParameterValue": "10.0.0.0/27"
   	},
   	{
-    	"ParameterKey": "CIDRForVaultPrivateSubnet1",
+    	"ParameterKey": "CIDRForPublicSubnet2",
+		  "ParameterValue": "10.0.0.32/27"
+  	},
+  	{
+    	"ParameterKey": "CIDRForPublicSubnet3",
+		  "ParameterValue": "10.0.0.64/27"
+  	},
+  	{
+    	"ParameterKey": "CIDRForPublicSubnet4",
 		  "ParameterValue": "10.0.0.96/27"
   	},
   	{
-    	"ParameterKey": "DeployVaultPrivateSubnet1",
-		  "ParameterValue": "yes"
-  	},
-  	{
-    	"ParameterKey": "CIDRForVaultPrivateSubnet2",
+    	"ParameterKey": "CIDRForPublicSubnet5",
 		  "ParameterValue": "10.0.0.128/27"
   	},
   	{
-    	"ParameterKey": "DeployVaultPrivateSubnet2",
-		  "ParameterValue": "yes"
-  	},
-  	{
-    	"ParameterKey": "CIDRForVaultPrivateSubnet3",
+    	"ParameterKey": "CIDRForVaultPrivateSubnet1",
 		  "ParameterValue": "10.0.0.160/27"
   	},
   	{
-    	"ParameterKey": "DeployVaultPrivateSubnet3",
-		  "ParameterValue": "yes"
-  	},
-  	{
-    	"ParameterKey": "CIDRForVaultPrivateSubnet4",
+    	"ParameterKey": "CIDRForVaultPrivateSubnet2",
 		  "ParameterValue": "10.0.0.192/27"
   	},
   	{
-    	"ParameterKey": "DeployVaultPrivateSubnet4",
-		  "ParameterValue": "no"
+    	"ParameterKey": "CIDRForVaultPrivateSubnet3",
+		  "ParameterValue": "10.0.0.224/27"
+  	},
+  	{
+    	"ParameterKey": "CIDRForVaultPrivateSubnet4",
+		  "ParameterValue": "10.0.1.0/27"
+  	},
+  	{
+    	"ParameterKey": "CIDRForVaultPrivateSubnet5",
+		  "ParameterValue": "10.0.1.32/27"
   	},
   	{
     	"ParameterKey": "VaultIngressCIDR",
-		  "ParameterValue": "77.97.82.48/32"
-  	}
+		  "ParameterValue": "195.10.20.30/32"
+  	},
+  	{
+    	"ParameterKey": "NumberOfSubnetNodes",
+		  "ParameterValue": "2"
+  	},
+    {
+      "ParameterKey": "VaultCoreEC2AMI",
+		  "ParameterValue": "ami-70edb016"
+    },
+    {
+      "ParameterKey": "VaultCoreEC2InstanceType",
+		  "ParameterValue": "t2.micro"
+    },
+    {
+      "ParameterKey": "VaultEC2KeyPair",
+		  "ParameterValue": "my_ec2_key"
+    },
+    {
+      "ParameterKey": "RequesterAccountNumber",
+		  "ParameterValue": "123456789012"
+    }
 ]

--- a/vault-core-networking.json
+++ b/vault-core-networking.json
@@ -1,6 +1,6 @@
 {
 "AWSTemplateFormatVersion" : "2010-09-09",
-"Description" : "Hashicorp Vault Reference: Core Network Infrastructure: This template creates the Private VPC for the Vault instances, between 1-4 Subnets (so it can be deployed in any region and these are enabled/disabled in the parameters), Routing Table, Routes, a NAT Gateway and Internet Gateway",
+"Description" : "HASHICORP VAULT REFERENCE (Core Network Infrastructure) - Creates a VPC, a set of Public and Private Subnets (1-5 depending on how many Availibility Zones there are in the Region), associated Routing Tables with Routes and an Internet and NAT Gateway.",
 
 	"Metadata" :
 	{
@@ -10,101 +10,134 @@
   {
       "VPCCIDR" :
       {
-        "Description" : "CIDR for Vault Reference VPC",
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Server Deployment",
         "Type" : "String",
         "Default" : "10.0.0.0/16"
       },
-      "AvailabilityZones":
-      {
-        "Description": "List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved.",
-        "Type": "List<AWS::EC2::AvailabilityZone::Name>"
-      },
       "CIDRForPublicSubnet1" :
       {
-        "Description" : "CIDR for Vault Reference Public Subnet 1",
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Public Subnet 1",
         "Type" : "String",
         "Default" : "10.0.0.0/27"
       },
       "CIDRForPublicSubnet2" :
       {
-        "Description" : "CIDR for Vault Reference Public Subnet 2",
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Public Subnet 2",
         "Type" : "String",
         "Default" : "10.0.0.32/27"
       },
       "CIDRForPublicSubnet3" :
       {
-        "Description" : "CIDR for Vault Reference PublicSubnet 3",
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Public Subnet 3",
         "Type" : "String",
         "Default" : "10.0.0.64/27"
       },
-      "CIDRForVaultPrivateSubnet1" :
+      "CIDRForPublicSubnet4" :
       {
-        "Description" : "CIDR for Vault Reference Private Subnet 1",
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Public Subnet 4",
         "Type" : "String",
         "Default" : "10.0.0.96/27"
       },
-      "DeployVaultPrivateSubnet1" :
+      "CIDRForPublicSubnet5" :
       {
-        "Description" : "Decision to Deploy or not to Deploy this Private Subnet 1.",
-        "Type" : "String",
-        "Default" : "yes"
-      },
-      "CIDRForVaultPrivateSubnet2" :
-      {
-        "Description" : "CIDR for Vault Reference Private Subnet 2",
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Public Subnet 5",
         "Type" : "String",
         "Default" : "10.0.0.128/27"
       },
-      "DeployVaultPrivateSubnet2" :
+      "CIDRForVaultPrivateSubnet1" :
       {
-        "Description" : "Decision to Deploy or not to Deploy this Private Subnet 2.",
-        "Type" : "String",
-        "Default" : "yes"
-      },
-      "CIDRForVaultPrivateSubnet3" :
-      {
-        "Description" : "CIDR for Vault Reference Private Subnet 3",
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Private Subnet 1",
         "Type" : "String",
         "Default" : "10.0.0.160/27"
       },
-      "DeployVaultPrivateSubnet3" :
+      "CIDRForVaultPrivateSubnet2" :
       {
-        "Description" : "Decision to Deploy or not to Deploy this Private Subnet 3.",
-        "Type" : "String",
-        "Default" : "yes"
-      },
-      "CIDRForVaultPrivateSubnet4" :
-      {
-        "Description" : "CIDR for Vault Reference Private Subnet 4",
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Private Subnet 2",
         "Type" : "String",
         "Default" : "10.0.0.192/27"
       },
-      "DeployVaultPrivateSubnet4" :
+      "CIDRForVaultPrivateSubnet3" :
       {
-        "Description" : "Decision to Deploy or not to Deploy this Private Subnet 4.",
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Private Subnet 3",
         "Type" : "String",
-        "Default" : "yes"
+        "Default" : "10.0.0.224/27"
       },
-      
+      "CIDRForVaultPrivateSubnet4" :
+      {
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Private Subnet 4",
+        "Type" : "String",
+        "Default" : "10.0.1.0/27"
+      },
+      "CIDRForVaultPrivateSubnet5" :
+      {
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Private Subnet 5",
+        "Type" : "String",
+        "Default" : "10.0.1.32/27"
+      },
+      "NumberOfSubnetNodes" :
+      {
+        "Description" : "Vault Core Infrastructure - Default, Min and Max Values for Number of Subnets (and therefore Instances) created to serve the Vault Core Software",
+        "Type" : "Number",
+        "Default" : 2,
+        "MinValue" : 2,
+        "MaxValue" : 5
+      },
       "VaultIngressCIDR" :
       {
-        "Description" : "CIDR for Vault Reference VPC",
-        "Type" : "String",
-        "Default" : "77.97.82.48/32"
+        "Description" : "Vault Core Infrastructure - CIDR for Vault Reference VPC",
+        "Type" : "String"
+      },
+      "VaultCoreEC2AMI" :
+      {
+        "Description" : "Vault Core Infrastructure - AMI Image ID for Vault Core Instances",
+        "Type" : "String"
+      },
+      "VaultCoreEC2InstanceType" :
+      {
+        "Description" : "Vault Core Infrastructure - Instance Type for Vault Core Instances",
+        "Type" : "String"
+      },
+      "VaultEC2KeyPair" :
+      {
+        "Description" : "Vault Core Infrastructure - Key Pair used to access the Vault Instances",
+        "Type" : "String"
+      },
+      "RequesterAccountNumber" :
+      {
+        "Type"                  : "String",
+        "Description"           : "Vault Core Infrastructure - Used when connecting perring between VPCs Number of the requester account",
+        "AllowedPattern"        : "[0-9]*",
+        "ConstraintDescription" : "Must be account number without dashes"
       }
       
 	},
 
 	"Mappings" :
 	{
+	    "RegionAZMap" :
+      {
+          "us-east-1" : { "1" : "us-east-1a", "2" : "us-east-1b", "3" : "us-east-1c", "4" : "us-east-1d", "5" : "us-east-1e" },
+          "us-east-2" : { "1" : "us-east-2a", "2" : "us-east-2b", "3" : "us-east-2c" },
+          "us-west-1" : { "1" : "us-west-1b", "2" : "us-west-1c" },
+          "us-west-2" : { "1" : "us-west-2a", "2" : "us-west-2b", "3" : "us-west-2c" },
+          "ca-central-1" : { "1" : "ca-central-1a", "2" : "ca-central-1b" },
+          "eu-west-1" : { "1" : "eu-west-1a", "2" : "eu-west-1b", "3" : "eu-west-1c"  },
+          "eu-central-1" : { "1" : "eu-central-1a", "2" : "eu-central-1b" },
+          "eu-west-2" : { "1" : "eu-west-2a", "2" : "eu-west-2b" },
+          "ap-southeast-1" : { "1" : "ap-southeast-1a", "2" : "ap-southeast-1b"  },
+          "ap-southeast-2" : { "1" : "ap-southeast-2a", "2" : "ap-southeast-2b", "3" : "ap-southeast-2c" },
+          "ap-northeast-2" : { "1" : "ap-northeast-2a", "2" : "ap-northeast-2c" },
+          "ap-northeast-1" : { "1" : "ap-northeast-1a", "2" : "ap-northeast-1c" },
+          "ap-south-1" : { "1" : "ap-south-1a", "2" : "ap-south-1b" },
+          "sa-east-1" : { "1" : "sa-east-1a", "2" : "sa-east-1b", "3" : "sa-east-1c" }
+      }
 	},
 
 	"Conditions" :
 	{
-	    "PrivateSubnet1Toggle" : { "Fn::Equals" : [ { "Ref" : "DeployVaultPrivateSubnet1" }, "yes" ] },
-	    "PrivateSubnet2Toggle" : { "Fn::Equals" : [ { "Ref" : "DeployVaultPrivateSubnet2" }, "yes" ] },
-	    "PrivateSubnet3Toggle" : { "Fn::Equals" : [ { "Ref" : "DeployVaultPrivateSubnet3" }, "yes" ] },
-	    "PrivateSubnet4Toggle" : { "Fn::Equals" : [ { "Ref" : "DeployVaultPrivateSubnet4" }, "yes" ] }
+	    "CreateNode5" : { "Fn::Equals" : [ { "Ref" : "NumberOfSubnetNodes" }, 5 ]},
+      "CreateNode4" : { "Fn::Or" : [ { "Fn::Equals" : [ { "Ref" : "NumberOfSubnetNodes" }, 4 ] }, { "Condition" : "CreateNode5" }]},
+      "CreateNode3" : { "Fn::Or" : [ { "Fn::Equals" : [ { "Ref" : "NumberOfSubnetNodes" }, 3 ] }, { "Condition" : "CreateNode4" }]}
 	},
 
 	"Resources" :
@@ -118,109 +151,161 @@
         		  "CidrBlock" : { "Ref" : "VPCCIDR"} ,
         		  "Tags" :
 					    [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"}},
-						  {"Key" : "Name", "Value" : "Vault Reference VPC"}]
+						  {"Key" : "Name", "Value" : "VAULT CORE REFERENCE: VPC"}]
       		}
    		},
    		
-  	    "VaultRefPublicSubnet1" :
+  	  "VaultRefPublicSubnet1" :
 	  	{
       		"Type" : "AWS::EC2::Subnet",
       		"Properties" :
 			    {
         			"VpcId" : { "Ref" : "VaultRefVPC" },
         			"CidrBlock" : { "Ref" : "CIDRForPublicSubnet1" },
-        			"AvailabilityZone" : { "Fn::Select": ["0",{ "Ref": "AvailabilityZones" }] },
+        			"AvailabilityZone" : { "Fn::FindInMap" : [ "RegionAZMap", { "Ref" : "AWS::Region" }, "1" ] },
         			"Tags" :
 					    [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
-					    {"Key" : "Name", "Value" : "Vault Reference Public Subnet 1"}]
+					    {"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Public Subnet 1"}]
       		}
     	},
 
       "VaultRefPublicSubnet2" :
       {
           "Type" : "AWS::EC2::Subnet",
+          "DependsOn" : "VaultRefPublicSubnet1",
           "Properties" :
           {
                 "VpcId" : { "Ref" : "VaultRefVPC" },
                 "CidrBlock" : { "Ref" : "CIDRForPublicSubnet2" },
-                "AvailabilityZone" : { "Fn::Select": ["1",{ "Ref": "AvailabilityZones" }] },
+                "AvailabilityZone" : { "Fn::FindInMap" : [ "RegionAZMap", { "Ref" : "AWS::Region" }, "2" ] },
                 "Tags" :
                 [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
-                {"Key" : "Name", "Value" : "Vault Reference Public Subnet 2"}]
+                {"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Public Subnet 2"}]
           }
       },
-
+      
       "VaultRefPublicSubnet3" :
       {
           "Type" : "AWS::EC2::Subnet",
+          "Condition" : "CreateNode3",
+          "DependsOn" : "VaultRefPublicSubnet2",
           "Properties" :
           {
-                  "VpcId" : { "Ref" : "VaultRefVPC" },
-                  "CidrBlock" : { "Ref" : "CIDRForPublicSubnet3" },
-                  "AvailabilityZone" : { "Fn::Select": ["2",{ "Ref": "AvailabilityZones" }] },
-                  "Tags" :
-                  [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
-                  {"Key" : "Name", "Value" : "Vault Reference Public Subnet 3"}]
+                "VpcId" : { "Ref" : "VaultRefVPC" },
+                "CidrBlock" : { "Ref" : "CIDRForPublicSubnet3" },
+                "AvailabilityZone" : { "Fn::FindInMap" : [ "RegionAZMap", { "Ref" : "AWS::Region" }, "3" ] },
+                "Tags" :
+                [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
+                {"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Public Subnet 3"}]
+          }
+      },
+      
+      "VaultRefPublicSubnet4" :
+      {
+          "Type" : "AWS::EC2::Subnet",
+          "Condition" : "CreateNode4",
+          "DependsOn" : "VaultRefPublicSubnet3",
+          "Properties" :
+          {
+                "VpcId" : { "Ref" : "VaultRefVPC" },
+                "CidrBlock" : { "Ref" : "CIDRForPublicSubnet4" },
+                "AvailabilityZone" : { "Fn::FindInMap" : [ "RegionAZMap", { "Ref" : "AWS::Region" }, "4" ] },
+                "Tags" :
+                [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
+                {"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Public Subnet 4"}]
+          }
+      },
+
+      "VaultRefPublicSubnet5" :
+      {
+          "Type" : "AWS::EC2::Subnet",
+          "Condition" : "CreateNode5",
+          "DependsOn" : "VaultRefPublicSubnet4",
+          "Properties" :
+          {
+                "VpcId" : { "Ref" : "VaultRefVPC" },
+                "CidrBlock" : { "Ref" : "CIDRForPublicSubnet5" },
+                "AvailabilityZone" : { "Fn::FindInMap" : [ "RegionAZMap", { "Ref" : "AWS::Region" }, "5" ] },
+                "Tags" :
+                [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
+                {"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Public Subnet 5"}]
           }
       },
 
     	"VaultRefPrivateSubnet1" :
 		  {
       		"Type" : "AWS::EC2::Subnet",
-      		"Condition" : "PrivateSubnet1Toggle",
       		"Properties" :
 			    {
         		"VpcId" : { "Ref" : "VaultRefVPC" },
         		"CidrBlock" : { "Ref" : "CIDRForVaultPrivateSubnet1" },
-        		"AvailabilityZone" : { "Fn::Select": ["0",{ "Ref": "AvailabilityZones" }] },
+        		"AvailabilityZone" : { "Fn::FindInMap" : [ "RegionAZMap", { "Ref" : "AWS::Region" }, "1" ] },
         		"Tags" :
 					  [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
-						{"Key" : "Name", "Value" : "Vault Reference Private Subnet 1"}]
+						{"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Private Subnet 1"}]
       		}
     	},
 
     	"VaultRefPrivateSubnet2" :
 		  {
       		"Type" : "AWS::EC2::Subnet",
-      		"Condition" : "PrivateSubnet2Toggle",
+      		"DependsOn" : "VaultRefPrivateSubnet1",
       		"Properties" :
 			    {
         		"VpcId" : { "Ref" : "VaultRefVPC" },
         		"CidrBlock" : { "Ref" : "CIDRForVaultPrivateSubnet2" },
-        		"AvailabilityZone" : { "Fn::Select": ["1",{ "Ref": "AvailabilityZones" }] },
+                "AvailabilityZone" : { "Fn::FindInMap" : [ "RegionAZMap", { "Ref" : "AWS::Region" }, "2" ] },
         		"Tags" :
 					  [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
-						{"Key" : "Name", "Value" : "Vault Reference Private Subnet 2"}]
+						{"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Private Subnet 2"}]
       		}
     	},
    
     	"VaultRefPrivateSubnet3" :
 		  {
       		"Type" : "AWS::EC2::Subnet",
-      		"Condition" : "PrivateSubnet3Toggle",
+          "Condition" : "CreateNode3",
+          "DependsOn" : "VaultRefPrivateSubnet2",
       		"Properties" :
 			    {
         		"VpcId" : { "Ref" : "VaultRefVPC" },
         		"CidrBlock" : { "Ref" : "CIDRForVaultPrivateSubnet3" },
-        		"AvailabilityZone" : { "Fn::Select": ["2",{ "Ref": "AvailabilityZones" }] },
+                "AvailabilityZone" : { "Fn::FindInMap" : [ "RegionAZMap", { "Ref" : "AWS::Region" }, "3" ] },
         		"Tags" :
 					  [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
-						{"Key" : "Name", "Value" : "Vault Reference Private Subnet 3"}]
+						{"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Private Subnet 3"}]
       		}
     	},
     	
       "VaultRefPrivateSubnet4" :
 		  {
       		"Type" : "AWS::EC2::Subnet",
-      		"Condition" : "PrivateSubnet4Toggle",
+          "Condition" : "CreateNode4",
+          "DependsOn" : "VaultRefPrivateSubnet3",
       		"Properties" :
 			    {
         		"VpcId" : { "Ref" : "VaultRefVPC" },
         		"CidrBlock" : { "Ref" : "CIDRForVaultPrivateSubnet4" },
-        		"AvailabilityZone" : { "Fn::Select": ["3",{ "Ref": "AvailabilityZones" }] },
+                "AvailabilityZone" : { "Fn::FindInMap" : [ "RegionAZMap", { "Ref" : "AWS::Region" }, "4" ] },
         		"Tags" :
 					  [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
-						{"Key" : "Name", "Value" : "Vault Reference Private Subnet 4"}]
+						{"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Private Subnet 4"}]
+      		}
+    	},
+    	
+      "VaultRefPrivateSubnet5" :
+		  {
+      		"Type" : "AWS::EC2::Subnet",
+          "Condition" : "CreateNode5",
+          "DependsOn" : "VaultRefPrivateSubnet4",
+      		"Properties" :
+			    {
+        		"VpcId" : { "Ref" : "VaultRefVPC" },
+        		"CidrBlock" : { "Ref" : "CIDRForVaultPrivateSubnet5" },
+                "AvailabilityZone" : { "Fn::FindInMap" : [ "RegionAZMap", { "Ref" : "AWS::Region" }, "5" ] },
+        		"Tags" :
+					  [{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
+						{"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Private Subnet 5"}]
       		}
     	},
     	
@@ -231,7 +316,7 @@
 				  {
 	        	"Tags" :
 						[{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
-						{"Key" : "Name", "Value" : "Vault Reference Internet Gateway"}]
+						{"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Internet Gateway"}]
 	      	}
 	    },
 
@@ -253,7 +338,7 @@
 	          "VpcId" : {"Ref" : "VaultRefVPC"},
 	        	"Tags" :
 						[{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
-						{"Key" : "Name", "Value" : "Vault Reference Private Routing Table"}]
+						{"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Private Routing Table"}]
           }
 	    },
 	    
@@ -265,7 +350,7 @@
 	        	"VpcId" : {"Ref" : "VaultRefVPC"},
 	        	"Tags" :
 						[{"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} },
-						{"Key" : "Name", "Value" : "Vault Reference Public Routing Table, used only for NAT Gateway"}]
+						{"Key" : "Name", "Value" : "VAULT CORE REFERENCE: Public Routing Table, used only for NAT Gateway"}]
 				  }
 	    },
 
@@ -294,6 +379,7 @@
 	    "VaultRefPublicSubnetRouteTableAssociation2" :
 		  {
 				  "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+				  "DependsOn" : "VaultRefPublicSubnet1",
 	      	"Properties" :
 				  {
 	            "SubnetId" : { "Ref" : "VaultRefPublicSubnet2" },
@@ -304,6 +390,8 @@
 	    "VaultRefPublicSubnetRouteTableAssociation3" :
 		  {
 				  "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+          "Condition" : "CreateNode3",
+          "DependsOn" : "VaultRefPublicSubnet2",
 	      	"Properties" :
 				  {
 	            "SubnetId" : { "Ref" : "VaultRefPublicSubnet3" },
@@ -311,10 +399,34 @@
 	      	}
 	    },
 	    
+	    "VaultRefPublicSubnetRouteTableAssociation4" :
+		  {
+				  "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+          "Condition" : "CreateNode4",
+          "DependsOn" : "VaultRefPublicSubnet3",
+	      	"Properties" :
+				  {
+	            "SubnetId" : { "Ref" : "VaultRefPublicSubnet4" },
+	        		"RouteTableId" : { "Ref" : "VaultRefPublicRouteTable" }
+	      	}
+	    },
+	    
+	    "VaultRefPublicSubnetRouteTableAssociation5" :
+		  {
+				  "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+          "Condition" : "CreateNode5",
+          "DependsOn" : "VaultRefPublicSubnet4",
+	      	"Properties" :
+				  {
+	            "SubnetId" : { "Ref" : "VaultRefPublicSubnet5" },
+	        		"RouteTableId" : { "Ref" : "VaultRefPublicRouteTable" }
+	      	}
+	    },
+	
+	    
 		  "VaultRefPrivateSubnetRouteTableAssociation1" :
 		  {
 			    "Type" : "AWS::EC2::SubnetRouteTableAssociation",
-      		"Condition" : "PrivateSubnet1Toggle",
 	      	"Properties" :
 				  {
 	        		"SubnetId" : { "Ref" : "VaultRefPrivateSubnet1" },
@@ -325,7 +437,7 @@
 			"VaultRefPrivateSubnetRouteTableAssociation2" :
 		  {
 			    "Type" : "AWS::EC2::SubnetRouteTableAssociation",
-      		"Condition" : "PrivateSubnet2Toggle",
+				  "DependsOn" : "VaultRefPrivateSubnet1",
 	      	"Properties" :
 				  {
 	        		"SubnetId" : { "Ref" : "VaultRefPrivateSubnet2" },
@@ -336,7 +448,8 @@
 			"VaultRefPrivateSubnetRouteTableAssociation3" :
 		  {
 			    "Type" : "AWS::EC2::SubnetRouteTableAssociation",
-      		"Condition" : "PrivateSubnet3Toggle",
+          "Condition" : "CreateNode3",
+          "DependsOn" : "VaultRefPrivateSubnet2",
 	      	"Properties" :
 				  {
 	        		"SubnetId" : { "Ref" : "VaultRefPrivateSubnet3" },
@@ -347,10 +460,23 @@
 			"VaultRefPrivateSubnetRouteTableAssociation4" :
 		  {
 			    "Type" : "AWS::EC2::SubnetRouteTableAssociation",
-      		"Condition" : "PrivateSubnet4Toggle",
+          "Condition" : "CreateNode4",
+          "DependsOn" : "VaultRefPrivateSubnet3",
 	      	"Properties" :
 				  {
 	        		"SubnetId" : { "Ref" : "VaultRefPrivateSubnet4" },
+	        		"RouteTableId" : { "Ref" : "VaultRefPrivateRouteTable" }
+	      	}
+	    },
+	    
+			"VaultRefPrivateSubnetRouteTableAssociation5" :
+		  {
+			    "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+          "Condition" : "CreateNode5",
+          "DependsOn" : "VaultRefPrivateSubnet4",
+	      	"Properties" :
+				  {
+	        		"SubnetId" : { "Ref" : "VaultRefPrivateSubnet5" },
 	        		"RouteTableId" : { "Ref" : "VaultRefPrivateRouteTable" }
 	      	}
 	    },
@@ -384,7 +510,28 @@
               "DestinationCidrBlock" : "0.0.0.0/0",
               "NatGatewayId" : { "Ref" : "VaultRefNAT" }
           }
+      },
+      
+    "VPCPeeringAuthorizerRole" :
+    {
+      "Type": "AWS::IAM::Role",
+      "Properties" :
+      {
+        "AssumeRolePolicyDocument":
+        {
+          "Statement": [{ "Effect": "Allow", "Principal": { "AWS": { "Fn::Join" : [ "", [ "arn:aws:iam::", { "Ref" : "RequesterAccountNumber" }, ":root" ] ] } }, "Action": "sts:AssumeRole" }]
+        },
+        
+        "Policies" :
+        [{
+            "PolicyName" : "VPCAuthorizer",
+            "PolicyDocument" :
+            {
+              "Statement" : [{ "Effect" : "Allow", "Action" : ["ec2:AcceptVpcPeeringConnection"], "Resource" : ["*"] }]
+            }
+        }]
       }
+    }
 	
 
 	},
@@ -398,69 +545,117 @@
 		  {
 	       "Ref": "VaultRefVPC"
 		  },
-	      "Description": "VPC ID"
+	      "Description": "VAULT CORE REFERENCE: VPC ID"
 	   },
+	   
+	  "SubnetNodeTotal" :
+	  {
+		  "Description": "VAULT CORE REFERENCE: Total number of subnets in Stack. (This value needs to be used in conjunction with the Region in which the Stack is deployed.)",
+	    "Value": { "Ref" : "NumberOfSubnetNodes" },
+	    "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-SubnetNodeTotal" }}
+	  },
 	  
 	  "VaultPublicSubnet1" :
 	  {
-      "Description": "ID of Public Subnet 1",
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 1",
       "Value" : { "Ref" : "VaultRefPublicSubnet1" }
     },
 	  
 		"VaultPublicSubnet2" :
 	  {
-      "Description": "ID of Public Subnet 2",
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 2",
       "Value" : { "Ref" : "VaultRefPublicSubnet2" }
     },
     
-    "VaultPublicSubnet3" :
+		"VaultPublicSubnet3" :
 	  {
-      "Description": "ID of Public Subnet 3",
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 3",
+      "Condition" : "CreateNode3",
       "Value" : { "Ref" : "VaultRefPublicSubnet3" }
+    },
+    
+		"VaultPublicSubnet4" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 4",
+      "Condition" : "CreateNode4",
+      "Value" : { "Ref" : "VaultRefPublicSubnet4" }
+    },
+    
+		"VaultPublicSubnet5" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 5",
+      "Condition" : "CreateNode5",
+      "Value" : { "Ref" : "VaultRefPublicSubnet5" }
     },
 	
 	  "VaultPrivateSubnet1" :
 	  {
-      "Description": "ID of Private Subnet 1",
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 1",
       "Value" : { "Ref" : "VaultRefPrivateSubnet1" }
-    },
-    
-    "VaultPrivateSubnet1Toggle" :
-	  {
-      "Description": "Should we Deploy Private Subnet 1? yes/no",
-      "Value" : { "Ref" : "DeployVaultPrivateSubnet1" }
     },
     
     "VaultPrivateSubnet2" :
 	  {
-      "Description": "ID of Private Subnet 2",
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 2",
       "Value" : { "Ref" : "VaultRefPrivateSubnet2" }
-    },
-    
-    "VaultPrivateSubnet2Toggle" :
-	  {
-      "Description": "Should we Deploy Private Subnet 2? yes/no",
-      "Value" : { "Ref" : "DeployVaultPrivateSubnet2" }
     },
     
     "VaultPrivateSubnet3" :
 	  {
-      "Description": "ID of Private Subnet 3",
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 3",
+      "Condition" : "CreateNode3",
       "Value" : { "Ref" : "VaultRefPrivateSubnet3" }
     },
     
-    "VaultPrivateSubnet3Toggle" :
+    "VaultPrivateSubnet4" :
 	  {
-      "Description": "Should we Deploy Private Subnet 3? yes/no",
-      "Value" : { "Ref" : "DeployVaultPrivateSubnet3" }
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 4",
+      "Condition" : "CreateNode4",
+      "Value" : { "Ref" : "VaultRefPrivateSubnet4" }
+    },
+    
+    "VaultPrivateSubnet5" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 5",
+      "Condition" : "CreateNode5",
+      "Value" : { "Ref" : "VaultRefPrivateSubnet5" }
     },
     
     "VaultCIDRBastionAccess" :
 	  {
-      "Description": "CIDR of IP used for access to Bastion host",
+      "Description": "VAULT CORE REFERENCE: CIDR of IP used for access to Bastion host",
       "Value" : { "Ref" : "VaultIngressCIDR" }
+    },
+    
+    "VaultImageID" :
+    {
+      "Description": "VAULT CORE REFERENCE: Image ID of AMI used for Vault Core Infrastructure",
+      "Value" : { "Ref" : "VaultCoreEC2AMI" }
+    },
+    
+    "VaultInstanceType" :
+    {
+      "Description": "VAULT CORE REFERENCE: Instance Type used for Vault Core Infrastructure",
+      "Value" : { "Ref" : "VaultCoreEC2InstanceType" }
+    },
+    
+    "VaultEC2KeyPair" :
+    {
+      "Description": "VAULT CORE REFERENCE: Key Pair used for Vault EC2 Instances",
+      "Value" : { "Ref" : "VaultEC2KeyPair" }
+    },
+    
+    "RoleName" :
+    {
+      "Description": "VAULT CORE REFERENCE - (VPC Peering): Cross Account Role Name",
+      "Value" : { "Ref" : "VPCPeeringAuthorizerRole" }
+    },
+    
+    "VaultAppAWSAccount" :
+    {
+      "Description": "VAULT CORE REFERENCE - (VPC Peering): AWS Account Number in which the App VPC is created",
+      "Value" : { "Ref" : "RequesterAccountNumber" }
     }
-	  
 	  
 	}
 }

--- a/vault-core-security.json
+++ b/vault-core-security.json
@@ -1,6 +1,6 @@
 {
 "AWSTemplateFormatVersion" : "2010-09-09",
-"Description" : "Hashicorp Vault Reference: Core Security Infrastructure: This template creates a Private and Public Security Group and 1 Test EC2 instance.",
+"Description" : "HASHICORP VAULT REFERENCE (Core Security Infrastructure) - Creates a Private and Public Security Group (and ultimately any NACLs required) for the ingress and egress of data in the VPC that builds the Vault infrastructure.",
 
 	"Metadata" :
 	{
@@ -11,19 +11,49 @@
 
       "VaultStackName":
       {
-        "Description": "Name of the stack containing the vault networking",
+        "Description": "Name of the Stack containing the Vault networking",
         "Type": "String"
+      },
+      
+      "NumberOfSubnetNodes" :
+      {
+        "Description" : "Vault Core Infrastructure - Default, Min and Max Values for Number of Subnets (and therefore Instances) created to serve the Vault Core Software",
+        "Type" : "Number",
+        "Default" : 2,
+        "MinValue" : 2,
+        "MaxValue" : 5
       }
   
   },
 
 	"Mappings" :
 	{
+	    "RegionAZMap" :
+      {
+          "us-east-1" : { "1" : "us-east-1a", "2" : "us-east-1b", "3" : "us-east-1c", "4" : "us-east-1d", "5" : "us-east-1e" },
+          "us-east-2" : { "1" : "us-east-2a", "2" : "us-east-2b", "3" : "us-east-2c" },
+          "us-west-1" : { "1" : "us-west-1b", "2" : "us-west-1c" },
+          "us-west-2" : { "1" : "us-west-2a", "2" : "us-west-2b", "3" : "us-west-2c" },
+          "ca-central-1" : { "1" : "ca-central-1a", "2" : "ca-central-1b" },
+          "eu-west-1" : { "1" : "eu-west-1a", "2" : "eu-west-1b", "3" : "eu-west-1c"  },
+          "eu-central-1" : { "1" : "eu-central-1a", "2" : "eu-central-1b" },
+          "eu-west-2" : { "1" : "eu-west-2a", "2" : "eu-west-2b" },
+          "ap-southeast-1" : { "1" : "ap-southeast-1a", "2" : "ap-southeast-1b"  },
+          "ap-southeast-2" : { "1" : "ap-southeast-2a", "2" : "ap-southeast-2b", "3" : "ap-southeast-2c" },
+          "ap-northeast-2" : { "1" : "ap-northeast-2a", "2" : "ap-northeast-2c" },
+          "ap-northeast-1" : { "1" : "ap-northeast-1a", "2" : "ap-northeast-1c" },
+          "ap-south-1" : { "1" : "ap-south-1a", "2" : "ap-south-1b" },
+          "sa-east-1" : { "1" : "sa-east-1a", "2" : "sa-east-1b", "3" : "sa-east-1c" }
+      }
   },
-
-	"Conditions" :
+  
+  "Conditions" :
 	{
-  },
+	    "CreateNode5" : { "Fn::Equals" : [ { "Ref" : "NumberOfSubnetNodes" }, 5 ]},
+      "CreateNode4" : { "Fn::Or" : [ { "Fn::Equals" : [ { "Ref" : "NumberOfSubnetNodes" }, 4 ] }, { "Condition" : "CreateNode5" }]},
+      "CreateNode3" : { "Fn::Or" : [ { "Fn::Equals" : [ { "Ref" : "NumberOfSubnetNodes" }, 3 ] }, { "Condition" : "CreateNode4" }]}
+	},
+
 
 	"Resources" :
   {
@@ -175,14 +205,22 @@
           {
             "GroupDescription" : "Allow http to client host",
             "VpcId" : { "Fn::GetAtt" : ["NetworkInfo","VaultRefVPC"] },
-            "SecurityGroupIngress" : [{
+            "SecurityGroupIngress" : [
+            {
                 "IpProtocol" : "tcp",
                 "FromPort" : "22",
                 "ToPort" : "22",
                 "CidrIp" :  "0.0.0.0/0"
+            },
+            {
+                "IpProtocol" : "tcp",
+                "FromPort" : "8200",
+                "ToPort" : "8200",
+                "CidrIp" :  "0.0.0.0/0"
             }],
             
-            "SecurityGroupEgress" : [{
+            "SecurityGroupEgress" : [
+            {
                 "IpProtocol" : "tcp",
                 "FromPort" : "443",
                 "ToPort" : "443",
@@ -201,74 +239,126 @@
 	  
 	  "VaultRefVPC":
 		{
-	     "Value": { "Fn::GetAtt" : ["NetworkInfo","VaultRefVPC"] },
-	     "Description": "VPC ID"
-	   },
-	  
+		  "Description": "VAULT CORE REFERENCE: VPC ID",
+	   "Value": { "Fn::GetAtt" : ["NetworkInfo","VaultRefVPC"] }
+	  },
+	  "SubnetNodeTotal":
+	  {
+	    "Description": "VAULT CORE REFERENCE: Total number of subnets in Stack. (This value needs to be used in conjunction with the Region in which the Stack is deployed.)",
+	    "Value": {"Fn::ImportValue" : {"Fn::Sub" : "${VaultStackName}-SubnetNodeTotal"}}
+	  },
 	  "VaultPublicSubnet1" :
 	  {
-      "Description": "ID of Public Subnet 1",
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 1",
       "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSubnet1"] }
     },
 	  
 		"VaultPublicSubnet2" :
 	  {
-      "Description": "ID of Public Subnet 2",
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 2",
       "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSubnet2"] }
     },
     
-    "VaultPublicSubnet3" :
+		"VaultPublicSubnet3" :
 	  {
-      "Description": "ID of Public Subnet 3",
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 3",
+      "Condition" : "CreateNode3",
       "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSubnet3"] }
     },
-	
+    
+		"VaultPublicSubnet4" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 4",
+      "Condition" : "CreateNode4",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSubnet4"] }
+    },
+    
+		"VaultPublicSubnet5" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Public Subnet 5",
+      "Condition" : "CreateNode5",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPublicSubnet5"] }
+    },
+    
 	  "VaultPrivateSubnet1" :
 	  {
-      "Description": "ID of Private Subnet 1",
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 1",
       "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet1"] }
     },
     
-    "VaultPrivateSubnet1Toggle" :
+    "VaultPrivateSubnet2" :
 	  {
-      "Description": "Should we Deploy Private Subnet 1? yes/no",
-      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet1Toggle"] }
-    },
-    
-  	"VaultPrivateSubnet2" :
-	  {
-      "Description": "ID of Private Subnet 2",
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 2",
       "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet2"] }
-    },
-    
-    "VaultPrivateSubnet2Toggle" :
-	  {
-      "Description": "Should we Deploy Private Subnet 2? yes/no",
-      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet2Toggle"] }
     },
     
     "VaultPrivateSubnet3" :
 	  {
-      "Description": "ID of Private Subnet 3",
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 3",
+      "Condition" : "CreateNode3",
       "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet3"] }
     },
     
-    "VaultPrivateSubnet3Toggle" :
+    "VaultPrivateSubnet4" :
 	  {
-      "Description": "Should we Deploy Private Subnet 3? yes/no",
-      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet3Toggle"] }
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 4",
+      "Condition" : "CreateNode4",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet4"] }
+    },
+    
+    "VaultPrivateSubnet5" :
+	  {
+      "Description": "VAULT CORE REFERENCE: ID of Private Subnet 5",
+      "Condition" : "CreateNode5",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultPrivateSubnet5"] }
+    },
+    
+    "VaultCIDRBastionAccess" :
+	  {
+      "Description": "VAULT CORE REFERENCE: CIDR of IP used for access to Bastion host",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultCIDRBastionAccess"] }
+    },
+    
+    "VaultImageID" :
+    {
+      "Description": "VAULT CORE REFERENCE: Image ID of AMI used for Vault Core Infrastructure",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultImageID"] }
+    },
+    
+    "VaultInstanceType" :
+    {
+      "Description": "VAULT CORE REFERENCE: Instance Type used for Vault Core Infrastructure",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultInstanceType"] }
+    },
+    
+    "VaultEC2KeyPair" :
+    {
+      "Description": "VAULT CORE REFERENCE: Key Pair used for Vault EC2 Instances",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultEC2KeyPair"] }
     },
     
     "VaultPublicSG" :
 	  {
-      "Description": "Vault Public Instance Security Group",
+      "Description": "VAULT CORE REFERENCE: Public Instance Security Group",
       "Value" : { "Ref" : "VaultPublicInstanceSecurityGroup"}
     },
     
     "VaultPrivateSG" :
 	  {
-      "Description": "Vault Private Instance Security Group",
+      "Description": "VAULT CORE REFERENCE: Private Instance Security Group",
       "Value" : { "Ref" : "VaultPrivateInstanceSecurityGroup"}
+    },
+    
+    "RoleName" :
+    {
+      "Description": "VAULT CORE REFERENCE - (VPC Peering): Cross Account Role Name",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","RoleName"] }
+    },
+    
+    "VaultAppAWSAccount" :
+    {
+      "Description": "VAULT CORE REFERENCE - (VPC Peering): AWS Account Number in which the App VPC is created",
+      "Value" : { "Fn::GetAtt" : ["NetworkInfo","VaultAppAWSAccount"] }
     }
 	  
   }


### PR DESCRIPTION
… allows

The Cloudformation template allows for a number to be passed to define the amount of subnets and EC2 instances to be created.  This means that it will now cope with being deployed into AWS Regions with up to 5 Availability Zones whilst still defaulting to 2 AZs. 